### PR TITLE
Remove process.exit because it exits calling app too

### DIFF
--- a/lib/OWIRobotArm.js
+++ b/lib/OWIRobotArm.js
@@ -4,8 +4,9 @@ function RobotArm() {
     this.device = usb.findByIds('0x1267', 0);
 
     if (!this.device) {
-        console.error("OWI USB Device not found!");
-        process.exit(1);
+        var errorMessage = "OWI USB Device not found!";
+        console.error(errorMessage);
+        throw errorMessage;
     }
 
     this.device.open();


### PR DESCRIPTION
Instead of process.exit, it should throw exception so I can catch it in the calling code, more information [here](https://www.nczonline.net/blog/2014/02/04/maintainable-node-js-javascript-avoid-process-exit/)

> Since any module can call process.exit(), that means any function call gone awry could decide to shut down the application. That’s not a good state to be in. There should be one area of an application that decides when and if to call process.exit() and what the exit code should be (that’s usually the application controller). Utilities and such should never use process.exit(), it’s way out of their realm of responsibility.
